### PR TITLE
Add allowed callbacks proposal

### DIFF
--- a/contracts/ERC827/proposals/ERC827Proxy.sol
+++ b/contracts/ERC827/proposals/ERC827Proxy.sol
@@ -1,0 +1,71 @@
+/* solium-disable security/no-low-level-calls */
+
+pragma solidity ^0.4.24;
+
+import "./ERC827TokenMockAllowedCallbacks.sol";
+
+/**
+ * @title ERC827Proxy
+ *
+ * @dev Proxy to forward tokens balance and allowance with arbitrary calls
+ */
+contract ERC827Proxy {
+
+  ERC827TokenAllowedCallbacks public token;
+
+  /**
+   * @dev Constructor
+   */
+  constructor(ERC827TokenAllowedCallbacks _token) public {
+    token = _token;
+    bytes4 makeCallSig = bytes4(keccak256('makeCall(address,bytes)'));
+    token.allowCallback(address(0), makeCallSig,
+      ERC827TokenAllowedCallbacks.FunctionType.Approve
+    );
+    token.allowCallback(address(0), makeCallSig,
+      ERC827TokenAllowedCallbacks.FunctionType.Transfer
+    );
+    token.allowCallback(address(0), makeCallSig,
+      ERC827TokenAllowedCallbacks.FunctionType.TransferFrom
+    );
+  }
+
+  /**
+   * @dev Fallback function that give back all tokens received
+   */
+  function() {
+    forwardTokens(msg.sender);
+  }
+
+  /**
+   * @dev Forward arbitary calls with token balance or allowance
+   * @param _target address The address which you want to transfer to
+   * @param _data bytes The data to be executed in the call
+   */
+  function makeCall(address _target, bytes _data) public returns (bool) {
+    require(msg.sender == address(token));
+
+    forwardTokens(_target);
+
+    // solium-disable-next-line security/no-call-value
+    return _target.call.value(msg.value)(_data);
+  }
+
+  /**
+   * @dev Give back all tokens balance and allowance to address
+   * @param to address The address which you want to transfer to
+   */
+  function forwardTokens(address to) internal {
+    uint256 callerBalance = token.balanceOf(address(this));
+    uint256 callerAllowance = token.allowance(to, address(this));
+
+    // Give back token balance
+    if (callerBalance > 0)
+      token.transfer(to, callerBalance);
+
+    // Give back token allowance
+    if (callerAllowance > 0)
+      token.transferFrom(address(this), to, callerAllowance);
+  }
+
+}

--- a/contracts/ERC827/proposals/ERC827TokenMockAllowedCallbacks.sol
+++ b/contracts/ERC827/proposals/ERC827TokenMockAllowedCallbacks.sol
@@ -1,0 +1,220 @@
+/* solium-disable security/no-low-level-calls */
+
+pragma solidity ^0.4.24;
+
+import "../../ERC20/StandardToken.sol";
+
+
+/**
+ * @title ERC827, an extension of ERC20 token standard
+ *
+ * @dev Implementation the ERC827, following the ERC20 standard with extra
+ * methods to transfer value and data and execute calls in transfers and
+ * approvals. Uses OpenZeppelin StandardToken.
+ */
+contract ERC827TokenAllowedCallbacks is StandardToken {
+
+  /**
+   * @dev Signatures fo the allowed callback allowed between contracts
+   * Receiver => Sender => Function Signature => Allowed
+   */
+  mapping(address => mapping(address => mapping(bytes4 => bool)))
+    public allowedCallbacks;
+
+  /**
+   * @dev Modifier that check the callback that wants to be executed
+   * If a receiver allows address(0) means that it can be called by anyone
+   * If a receiver allows bytes4(0) means that any function can be called
+   */
+  modifier callbackAllowed(address to, bytes4 functionSignature) {
+    // TO DO: Get first 4 bytes from data instead of using function signature
+    require(isCallbackAllowed(msg.sender, to, functionSignature));
+    _;
+  }
+
+  /**
+   * @dev Allows a callback function to be executed to a receiver contract
+   * @param from address The address that can execute the callback
+   * @param functionSignature bytes4 The signature of the callback function
+   */
+  function allowCallback(address from, bytes4 functionSignature) public {
+    // TO DO: Check that msg.sender is a contract ?
+    allowedCallbacks[msg.sender][from][functionSignature] = true;
+  }
+
+  /**
+   * @dev Remove a callback function to be executed to a receiver contract
+   * @param from address The address that can execute the callback
+   * @param functionSignature bytes4 The signature of the callback function
+   */
+  function removeCallback(address from, bytes4 functionSignature) public {
+    // TO DO: Check that msg.sender is a contract ?
+    allowedCallbacks[msg.sender][from][functionSignature] = false;
+  }
+
+  /**
+   * @dev Addition to ERC20 token methods. It allows to
+   * approve the transfer of value and execute a call with the sent data.
+   * Beware that changing an allowance with this method brings the risk that
+   * someone may use both the old and the new allowance by unfortunate
+   * transaction ordering. One possible solution to mitigate this race condition
+   * is to first reduce the spender's allowance to 0 and set the desired value
+   * afterwards:
+   * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+   * @param _spender The address that will spend the funds.
+   * @param _value The amount of tokens to be spent.
+   * @param _data ABI-encoded contract call to call `_spender` address.
+   * @return true if the call function was executed successfully
+   */
+  function approveAndCall(
+    address _spender,
+    uint256 _value,
+    bytes4 _functionSignature,
+    bytes _data
+  )
+    public payable callbackAllowed(_spender, _functionSignature) returns (bool)
+  {
+    require(_spender != address(this));
+
+    super.approve(_spender, _value);
+
+    // solium-disable-next-line security/no-call-value
+    require(_spender.call.value(msg.value)(_data));
+
+    return true;
+  }
+
+  /**
+   * @dev Addition to ERC20 token methods. Transfer tokens to a specified
+   * address and execute a call with the sent data on the same transaction
+   * @param _to address The address which you want to transfer to
+   * @param _value uint256 the amout of tokens to be transfered
+   * @param _data ABI-encoded contract call to call `_to` address.
+   * @return true if the call function was executed successfully
+   */
+  function transferAndCall(
+    address _to,
+    uint256 _value,
+    bytes4 _functionSignature,
+    bytes _data
+  )
+    public payable callbackAllowed(_to, _functionSignature) returns (bool)
+  {
+    require(_to != address(this));
+
+    super.transfer(_to, _value);
+
+    // solium-disable-next-line security/no-call-value
+    require(_to.call.value(msg.value)(_data));
+    return true;
+  }
+
+  /**
+   * @dev Addition to ERC20 token methods. Transfer tokens from one address to
+   * another and make a contract call on the same transaction
+   * @param _from The address which you want to send tokens from
+   * @param _to The address which you want to transfer to
+   * @param _value The amout of tokens to be transferred
+   * @param _data ABI-encoded contract call to call `_to` address.
+   * @return true if the call function was executed successfully
+   */
+  function transferFromAndCall(
+    address _from,
+    address _to,
+    uint256 _value,
+    bytes4 _functionSignature,
+    bytes _data
+  )
+    public payable callbackAllowed(_to, _functionSignature) returns (bool)
+  {
+    require(_to != address(this));
+
+    super.transferFrom(_from, _to, _value);
+
+    // solium-disable-next-line security/no-call-value
+    require(_to.call.value(msg.value)(_data));
+    return true;
+  }
+
+  /**
+   * @dev Addition to StandardToken methods. Increase the amount of tokens that
+   * an owner allowed to a spender and execute a call with the sent data.
+   * approve should be called when allowed[_spender] == 0. To increment
+   * allowed value is better to use this function to avoid 2 calls (and wait until
+   * the first transaction is mined)
+   * From MonolithDAO Token.sol
+   * @param _spender The address which will spend the funds.
+   * @param _addedValue The amount of tokens to increase the allowance by.
+   * @param _data ABI-encoded contract call to call `_spender` address.
+   */
+  function increaseApprovalAndCall(
+    address _spender,
+    uint _addedValue,
+    bytes4 _functionSignature,
+    bytes _data
+  )
+    public payable callbackAllowed(_spender, _functionSignature) returns (bool)
+  {
+    require(_spender != address(this));
+
+    super.increaseApproval(_spender, _addedValue);
+
+    // solium-disable-next-line security/no-call-value
+    require(_spender.call.value(msg.value)(_data));
+
+    return true;
+  }
+
+  /**
+   * @dev Addition to StandardToken methods. Decrease the amount of tokens that
+   * an owner allowed to a spender and execute a call with the sent data.
+   * approve should be called when allowed[_spender] == 0. To decrement
+   * allowed value is better to use this function to avoid 2 calls (and wait until
+   * the first transaction is mined)
+   * From MonolithDAO Token.sol
+   * @param _spender The address which will spend the funds.
+   * @param _subtractedValue The amount of tokens to decrease the allowance by.
+   * @param _data ABI-encoded contract call to call `_spender` address.
+   */
+  function decreaseApprovalAndCall(
+    address _spender,
+    uint _subtractedValue,
+    bytes4 _functionSignature,
+    bytes _data
+  )
+    public payable callbackAllowed(_spender, _functionSignature) returns (bool)
+  {
+    require(_spender != address(this));
+
+    super.decreaseApproval(_spender, _subtractedValue);
+
+    // solium-disable-next-line security/no-call-value
+    require(_spender.call.value(msg.value)(_data));
+
+    return true;
+  }
+
+  /**
+   * @dev Receives true or false depending if the callback can be executed
+   */
+  function isCallbackAllowed(
+    address from, address to, bytes4 functionSignature
+  ) public view returns(bool) {
+    return(
+      allowedCallbacks[to][address(0)][bytes4(0)] ||
+      allowedCallbacks[to][address(0)][functionSignature] ||
+      allowedCallbacks[to][from][functionSignature]
+    );
+  }
+
+}
+
+// mock class using ERC827 Token
+contract ERC827TokenMockAllowedCallbacks is ERC827TokenAllowedCallbacks {
+
+  constructor(address initialAccount, uint256 initialBalance) public {
+    balances[initialAccount] = initialBalance;
+    totalSupply_ = initialBalance;
+  }
+
+}

--- a/contracts/mocks/MessageHelper.sol
+++ b/contracts/mocks/MessageHelper.sol
@@ -41,10 +41,7 @@ contract MessageHelper {
 
   function call(address to, bytes data) public returns (bool) {
     // solium-disable-next-line security/no-low-level-calls
-    if (to.call(data))
-      return true;
-    else
-      return false;
+    require(to.call(data));
   }
 
 }

--- a/test/proposals/AllowedCallbaks.js
+++ b/test/proposals/AllowedCallbaks.js
@@ -25,147 +25,177 @@ contract('ERC827 Token proposal with allowed callbacks', function (accounts) {
   it('should allow execution of ERC827 tranfer on receiver that allows a function from a specific address', async function () {
     let allowCallbackData = token.contract.allowCallback.getData(accounts[0], functionSignature, 2);
 
-    await message.call(token.contract.address, allowCallbackData);
+    await message.call(token.address, allowCallbackData);
     assert.equal(true,
       await token.isCallbackAllowed(accounts[0], message.address, functionSignature, 2)
     );
 
-    let transaction = await token.transferAndCall(
-      message.contract.address, 100, functionSignature, messageData
+    await token.transferAndCall(
+      message.address, 100, messageData
     );
 
-    assert.equal(100, await token.balanceOf(message.contract.address));
+    assert.equal(100, await token.balanceOf(message.address));
   });
 
   it('should allow execution of ERC827 tranfer on receiver that allows a function from any address', async function () {
     let allowCallbackData = token.contract.allowCallback.getData(0x0, functionSignature, 2);
 
-    await message.call(token.contract.address, allowCallbackData);
+    await message.call(token.address, allowCallbackData);
     assert.equal(true,
       await token.isCallbackAllowed(accounts[0], message.address, functionSignature, 2)
     );
 
-    let transaction = await token.transferAndCall(
-      message.contract.address, 100, functionSignature, messageData
+    await token.transferAndCall(
+      message.address, 100, messageData
     );
 
-    assert.equal(100, await token.balanceOf(message.contract.address));
+    assert.equal(100, await token.balanceOf(message.address));
   });
 
   it('should allow execution of ERC827 tranfer on receiver that allows any function from any address', async function () {
     let allowCallbackData = token.contract.allowCallback.getData(0x0, 0x0, 2);
 
-    await message.call(token.contract.address, allowCallbackData);
+    await message.call(token.address, allowCallbackData);
     assert.equal(true,
       await token.isCallbackAllowed(accounts[0], message.address, functionSignature, 2)
     );
 
-    let transaction = await token.transferAndCall(
-      message.contract.address, 100, functionSignature, messageData
+    await token.transferAndCall(
+      message.address, 100, messageData
     );
 
-    assert.equal(100, await token.balanceOf(message.contract.address));
+    assert.equal(100, await token.balanceOf(message.address));
   });
 
   it('should allow execution of ERC827 approve on receiver that allows a function from a specific address', async function () {
     let allowCallbackData = token.contract.allowCallback.getData(accounts[0], functionSignature, 1);
 
-    await message.call(token.contract.address, allowCallbackData);
+    await message.call(token.address, allowCallbackData);
     assert.equal(true,
       await token.isCallbackAllowed(accounts[0], message.address, functionSignature, 1)
     );
 
-    let transaction = await token.approveAndCall(
-      message.contract.address, 100, functionSignature, messageData
+    await token.approveAndCall(
+      message.address, 100, messageData
     );
 
-    assert.equal(100, await token.allowance(accounts[0], message.contract.address));
+    assert.equal(100, await token.allowance(accounts[0], message.address));
   });
 
   it('should allow execution of ERC827 approve on receiver that allows a function from any address', async function () {
     let allowCallbackData = token.contract.allowCallback.getData(0x0, functionSignature, 1);
 
-    await message.call(token.contract.address, allowCallbackData);
+    await message.call(token.address, allowCallbackData);
     assert.equal(true,
       await token.isCallbackAllowed(accounts[0], message.address, functionSignature, 1)
     );
 
-    let transaction = await token.approveAndCall(
-      message.contract.address, 100, functionSignature, messageData
+    await token.approveAndCall(
+      message.address, 100, messageData
     );
 
-    assert.equal(100, await token.allowance(accounts[0], message.contract.address));
+    assert.equal(100, await token.allowance(accounts[0], message.address));
   });
 
   it('should allow execution of ERC827 approve on receiver that allows any function from any address', async function () {
     let allowCallbackData = token.contract.allowCallback.getData(0x0, 0x0, 1);
 
-    await message.call(token.contract.address, allowCallbackData);
+    await message.call(token.address, allowCallbackData);
     assert.equal(true,
       await token.isCallbackAllowed(accounts[0], message.address, functionSignature, 1)
     );
 
-    let transaction = await token.approveAndCall(
-      message.contract.address, 100, functionSignature, messageData
+    await token.approveAndCall(
+      message.address, 100, messageData
     );
 
-    assert.equal(100, await token.allowance(accounts[0], message.contract.address));
+    assert.equal(100, await token.allowance(accounts[0], message.address));
   });
 
   it('should allow execution of ERC827 tranferFrom on receiver that allows a function from a specific address', async function () {
     await token.approve(accounts[1], 100);
     let allowCallbackData = token.contract.allowCallback.getData(accounts[1], functionSignature, 3);
 
-    await message.call(token.contract.address, allowCallbackData);
+    await message.call(token.address, allowCallbackData);
     assert.equal(true,
       await token.isCallbackAllowed(accounts[1], message.address, functionSignature, 3)
     );
 
-    let transaction = await token.transferFromAndCall(
-      accounts[0], message.contract.address, 100, functionSignature, messageData,
+    await token.transferFromAndCall(
+      accounts[0], message.address, 100, messageData,
       {from: accounts[1]}
     );
 
-    assert.equal(100, await token.balanceOf(message.contract.address));
+    assert.equal(100, await token.balanceOf(message.address));
   });
 
   it('should allow execution of ERC827 tranferFrom on receiver that allows a function from any address', async function () {
     await token.approve(accounts[1], 100);
     let allowCallbackData = token.contract.allowCallback.getData(0x0, functionSignature, 3);
 
-    await message.call(token.contract.address, allowCallbackData);
+    await message.call(token.address, allowCallbackData);
     assert.equal(true,
       await token.isCallbackAllowed(accounts[1], message.address, functionSignature, 3)
     );
 
-    let transaction = await token.transferFromAndCall(
-      accounts[0], message.contract.address, 100, functionSignature, messageData,
+    await token.transferFromAndCall(
+      accounts[0], message.address, 100, messageData,
       {from: accounts[1]}
     );
 
-    assert.equal(100, await token.balanceOf(message.contract.address));
+    assert.equal(100, await token.balanceOf(message.address));
   });
 
   it('should allow execution of ERC827 tranferFrom on receiver that allows any function from any address', async function () {
     await token.approve(accounts[1], 100);
     let allowCallbackData = token.contract.allowCallback.getData(0x0, 0x0, 3);
 
-    await message.call(token.contract.address, allowCallbackData);
+    await message.call(token.address, allowCallbackData);
     assert.equal(true,
       await token.isCallbackAllowed(accounts[1], message.address, functionSignature, 3)
     );
 
-    let transaction = await token.transferFromAndCall(
-      accounts[0], message.contract.address, 100, functionSignature, messageData,
+    await token.transferFromAndCall(
+      accounts[0], message.address, 100, messageData,
       {from: accounts[1]}
     );
 
-    assert.equal(100, await token.balanceOf(message.contract.address));
+    assert.equal(100, await token.balanceOf(message.address));
+  });
+
+  it('should fail execution of ERC827 tranferFrom when only approval and transfer are allowed for that function', async function () {
+    let message2 = await Message.new();
+
+    let allowCallbackData = token.contract.allowCallback.getData(0x0, functionSignature, 1);
+    await message.call(token.address, allowCallbackData);
+
+    allowCallbackData = token.contract.allowCallback.getData(0x0, functionSignature, 2);
+    await message.call(token.address, allowCallbackData);
+
+    assert.equal(true,
+      await token.isCallbackAllowed(accounts[0], message.address, functionSignature, 1)
+    );
+    assert.equal(true,
+      await token.isCallbackAllowed(accounts[0], message.address, functionSignature, 2)
+    );
+    assert.equal(false,
+      await token.isCallbackAllowed(message.address, message2.address, functionSignature, 3)
+    );
+
+    await token.approveAndCall(message.address, 100, messageData);
+
+    let transferFromAndCallData = token.contract.transferFromAndCall.getData(
+      accounts[0], message2.address, 100, messageData
+    );
+    await message.call(token.address, transferFromAndCallData)
+      .should.be.rejectedWith(EVMRevert);
+
+    assert.equal(100, await token.balanceOf(accounts[0]));
   });
 
   it('Should fail when trying to execute not allowed function on receiver contract', async function () {
-    let transaction = await token.transferAndCall(
-      message.contract.address, 100, functionSignature, messageData
+    await token.transferAndCall(
+      message.address, 100, messageData
     ).should.be.rejectedWith(EVMRevert);
 
     assert.equal(100, await token.balanceOf(accounts[0]));

--- a/test/proposals/AllowedCallbaks.js
+++ b/test/proposals/AllowedCallbaks.js
@@ -1,0 +1,107 @@
+
+import EVMRevert from '../helpers/EVMRevert';
+var Message = artifacts.require('./mocks/MessageHelper');
+var ERC827TokenMock = artifacts.require('./ERC827/proposals/ERC827TokenMockAllowedCallbacks');
+
+var BigNumber = web3.BigNumber;
+require('chai')
+  .use(require('chai-as-promised'))
+  .use(require('chai-bignumber')(BigNumber))
+  .should();
+
+contract('ERC827 Token proposal with allowed callbacks', function (accounts) {
+  let token;
+
+  beforeEach(async function () {
+    token = await ERC827TokenMock.new(accounts[0], 100);
+  });
+
+  it('should allow execution of ERC827 tranfer on receiver that allows a function from a specific address', async function () {
+    let message = await Message.new();
+
+    let data = message.contract.showMessage.getData(web3.toHex(123456), 666, 'Transfer Done');
+
+    let signature = data.substring(0, 10);
+
+    assert.equal(false,
+      await token.isCallbackAllowed(accounts[0], message.address, signature)
+    );
+
+    let allowCallbackData = token.contract.allowCallback.getData(accounts[0], signature);
+
+    await message.call(token.contract.address, allowCallbackData);
+    assert.equal(true,
+      await token.isCallbackAllowed(accounts[0], message.address, signature)
+    );
+
+    let transaction = await token.transferAndCall(
+      message.contract.address, 100, signature, data
+    );
+
+    assert.equal(100, await token.balanceOf(message.contract.address));
+  });
+
+  it('should allow execution of ERC827 tranfer on receiver that allows a function from any address', async function () {
+    let message = await Message.new();
+
+    let data = message.contract.showMessage.getData(web3.toHex(123456), 666, 'Transfer Done');
+
+    let signature = data.substring(0, 10);
+
+    assert.equal(false,
+      await token.isCallbackAllowed(accounts[0], message.address, signature)
+    );
+
+    let allowCallbackData = token.contract.allowCallback.getData(0x0, signature);
+
+    await message.call(token.contract.address, allowCallbackData);
+    assert.equal(true,
+      await token.isCallbackAllowed(accounts[0], message.address, signature)
+    );
+
+    let transaction = await token.transferAndCall(
+      message.contract.address, 100, signature, data
+    );
+
+    assert.equal(100, await token.balanceOf(message.contract.address));
+  });
+
+  it('should allow execution of ERC827 tranfer on receiver that allows any function from any address', async function () {
+    let message = await Message.new();
+
+    let data = message.contract.showMessage.getData(web3.toHex(123456), 666, 'Transfer Done');
+
+    let signature = data.substring(0, 10);
+
+    assert.equal(false,
+      await token.isCallbackAllowed(accounts[0], message.address, signature)
+    );
+
+    let allowCallbackData = token.contract.allowCallback.getData(0x0, 0x0);
+
+    await message.call(token.contract.address, allowCallbackData);
+    assert.equal(true,
+      await token.isCallbackAllowed(accounts[0], message.address, signature)
+    );
+
+    let transaction = await token.transferAndCall(
+      message.contract.address, 100, signature, data
+    );
+
+    assert.equal(100, await token.balanceOf(message.contract.address));
+  });
+
+  it('Should fail when trying to execute not allowed function on receiver contract', async function () {
+    let message = await Message.new();
+
+    let data = message.contract.showMessage.getData(web3.toHex(123456), 666, 'Transfer Done');
+
+    let signature = data.substring(0, 10);
+
+    let transaction = await token.transferAndCall(
+      message.contract.address, 100, signature, data
+    ).should.be.rejectedWith(EVMRevert);
+
+    assert.equal(100, await token.balanceOf(accounts[0]));
+  });
+});

--- a/test/proposals/AllowedCallbaks.js
+++ b/test/proposals/AllowedCallbaks.js
@@ -10,96 +10,162 @@ require('chai')
   .should();
 
 contract('ERC827 Token proposal with allowed callbacks', function (accounts) {
-  let token;
+  let token, message, messageData, functionSignature;
+
+  before(async function () {
+    message = await Message.new();
+    messageData = message.contract.showMessage.getData(web3.toHex(123456), 666, 'Transfer Done');
+    functionSignature = messageData.substring(0, 10);
+  });
 
   beforeEach(async function () {
     token = await ERC827TokenMock.new(accounts[0], 100);
   });
 
   it('should allow execution of ERC827 tranfer on receiver that allows a function from a specific address', async function () {
-    let message = await Message.new();
-
-    let data = message.contract.showMessage.getData(web3.toHex(123456), 666, 'Transfer Done');
-
-    let signature = data.substring(0, 10);
-
-    assert.equal(false,
-      await token.isCallbackAllowed(accounts[0], message.address, signature)
-    );
-
-    let allowCallbackData = token.contract.allowCallback.getData(accounts[0], signature);
+    let allowCallbackData = token.contract.allowCallback.getData(accounts[0], functionSignature, 2);
 
     await message.call(token.contract.address, allowCallbackData);
     assert.equal(true,
-      await token.isCallbackAllowed(accounts[0], message.address, signature)
+      await token.isCallbackAllowed(accounts[0], message.address, functionSignature, 2)
     );
 
     let transaction = await token.transferAndCall(
-      message.contract.address, 100, signature, data
+      message.contract.address, 100, functionSignature, messageData
     );
 
     assert.equal(100, await token.balanceOf(message.contract.address));
   });
 
   it('should allow execution of ERC827 tranfer on receiver that allows a function from any address', async function () {
-    let message = await Message.new();
-
-    let data = message.contract.showMessage.getData(web3.toHex(123456), 666, 'Transfer Done');
-
-    let signature = data.substring(0, 10);
-
-    assert.equal(false,
-      await token.isCallbackAllowed(accounts[0], message.address, signature)
-    );
-
-    let allowCallbackData = token.contract.allowCallback.getData(0x0, signature);
+    let allowCallbackData = token.contract.allowCallback.getData(0x0, functionSignature, 2);
 
     await message.call(token.contract.address, allowCallbackData);
     assert.equal(true,
-      await token.isCallbackAllowed(accounts[0], message.address, signature)
+      await token.isCallbackAllowed(accounts[0], message.address, functionSignature, 2)
     );
 
     let transaction = await token.transferAndCall(
-      message.contract.address, 100, signature, data
+      message.contract.address, 100, functionSignature, messageData
     );
 
     assert.equal(100, await token.balanceOf(message.contract.address));
   });
 
   it('should allow execution of ERC827 tranfer on receiver that allows any function from any address', async function () {
-    let message = await Message.new();
-
-    let data = message.contract.showMessage.getData(web3.toHex(123456), 666, 'Transfer Done');
-
-    let signature = data.substring(0, 10);
-
-    assert.equal(false,
-      await token.isCallbackAllowed(accounts[0], message.address, signature)
-    );
-
-    let allowCallbackData = token.contract.allowCallback.getData(0x0, 0x0);
+    let allowCallbackData = token.contract.allowCallback.getData(0x0, 0x0, 2);
 
     await message.call(token.contract.address, allowCallbackData);
     assert.equal(true,
-      await token.isCallbackAllowed(accounts[0], message.address, signature)
+      await token.isCallbackAllowed(accounts[0], message.address, functionSignature, 2)
     );
 
     let transaction = await token.transferAndCall(
-      message.contract.address, 100, signature, data
+      message.contract.address, 100, functionSignature, messageData
+    );
+
+    assert.equal(100, await token.balanceOf(message.contract.address));
+  });
+
+  it('should allow execution of ERC827 approve on receiver that allows a function from a specific address', async function () {
+    let allowCallbackData = token.contract.allowCallback.getData(accounts[0], functionSignature, 1);
+
+    await message.call(token.contract.address, allowCallbackData);
+    assert.equal(true,
+      await token.isCallbackAllowed(accounts[0], message.address, functionSignature, 1)
+    );
+
+    let transaction = await token.approveAndCall(
+      message.contract.address, 100, functionSignature, messageData
+    );
+
+    assert.equal(100, await token.allowance(accounts[0], message.contract.address));
+  });
+
+  it('should allow execution of ERC827 approve on receiver that allows a function from any address', async function () {
+    let allowCallbackData = token.contract.allowCallback.getData(0x0, functionSignature, 1);
+
+    await message.call(token.contract.address, allowCallbackData);
+    assert.equal(true,
+      await token.isCallbackAllowed(accounts[0], message.address, functionSignature, 1)
+    );
+
+    let transaction = await token.approveAndCall(
+      message.contract.address, 100, functionSignature, messageData
+    );
+
+    assert.equal(100, await token.allowance(accounts[0], message.contract.address));
+  });
+
+  it('should allow execution of ERC827 approve on receiver that allows any function from any address', async function () {
+    let allowCallbackData = token.contract.allowCallback.getData(0x0, 0x0, 1);
+
+    await message.call(token.contract.address, allowCallbackData);
+    assert.equal(true,
+      await token.isCallbackAllowed(accounts[0], message.address, functionSignature, 1)
+    );
+
+    let transaction = await token.approveAndCall(
+      message.contract.address, 100, functionSignature, messageData
+    );
+
+    assert.equal(100, await token.allowance(accounts[0], message.contract.address));
+  });
+
+  it('should allow execution of ERC827 tranferFrom on receiver that allows a function from a specific address', async function () {
+    await token.approve(accounts[1], 100);
+    let allowCallbackData = token.contract.allowCallback.getData(accounts[1], functionSignature, 3);
+
+    await message.call(token.contract.address, allowCallbackData);
+    assert.equal(true,
+      await token.isCallbackAllowed(accounts[1], message.address, functionSignature, 3)
+    );
+
+    let transaction = await token.transferFromAndCall(
+      accounts[0], message.contract.address, 100, functionSignature, messageData,
+      {from: accounts[1]}
+    );
+
+    assert.equal(100, await token.balanceOf(message.contract.address));
+  });
+
+  it('should allow execution of ERC827 tranferFrom on receiver that allows a function from any address', async function () {
+    await token.approve(accounts[1], 100);
+    let allowCallbackData = token.contract.allowCallback.getData(0x0, functionSignature, 3);
+
+    await message.call(token.contract.address, allowCallbackData);
+    assert.equal(true,
+      await token.isCallbackAllowed(accounts[1], message.address, functionSignature, 3)
+    );
+
+    let transaction = await token.transferFromAndCall(
+      accounts[0], message.contract.address, 100, functionSignature, messageData,
+      {from: accounts[1]}
+    );
+
+    assert.equal(100, await token.balanceOf(message.contract.address));
+  });
+
+  it('should allow execution of ERC827 tranferFrom on receiver that allows any function from any address', async function () {
+    await token.approve(accounts[1], 100);
+    let allowCallbackData = token.contract.allowCallback.getData(0x0, 0x0, 3);
+
+    await message.call(token.contract.address, allowCallbackData);
+    assert.equal(true,
+      await token.isCallbackAllowed(accounts[1], message.address, functionSignature, 3)
+    );
+
+    let transaction = await token.transferFromAndCall(
+      accounts[0], message.contract.address, 100, functionSignature, messageData,
+      {from: accounts[1]}
     );
 
     assert.equal(100, await token.balanceOf(message.contract.address));
   });
 
   it('Should fail when trying to execute not allowed function on receiver contract', async function () {
-    let message = await Message.new();
-
-    let data = message.contract.showMessage.getData(web3.toHex(123456), 666, 'Transfer Done');
-
-    let signature = data.substring(0, 10);
-
     let transaction = await token.transferAndCall(
-      message.contract.address, 100, signature, data
+      message.contract.address, 100, functionSignature, messageData
     ).should.be.rejectedWith(EVMRevert);
 
     assert.equal(100, await token.balanceOf(accounts[0]));

--- a/test/proposals/ERC827Proxy.js
+++ b/test/proposals/ERC827Proxy.js
@@ -1,0 +1,51 @@
+
+import EVMRevert from '../helpers/EVMRevert';
+var Message = artifacts.require('./mocks/MessageHelper');
+var ERC827TokenMock = artifacts.require('./ERC827/proposals/ERC827TokenMockAllowedCallbacks');
+var ERC827Proxy = artifacts.require('./ERC827/proposals/ERC827Proxy');
+
+var BigNumber = web3.BigNumber;
+require('chai')
+  .use(require('chai-as-promised'))
+  .use(require('chai-bignumber')(BigNumber))
+  .should();
+
+contract('ERC827 Proxy for allowed callbacks', function (accounts) {
+  let token, message, messageData, functionSignature;
+
+  before(async function () {
+    message = await Message.new();
+    messageData = message.contract.showMessage.getData(web3.toHex(123456), 666, 'Transfer Done');
+    functionSignature = messageData.substring(0, 10);
+  });
+
+  beforeEach(async function () {
+    token = await ERC827TokenMock.new(accounts[0], 100);
+  });
+
+  it('should forward token balance correctly with ERC827Proxy', async function () {
+    let proxy = await ERC827Proxy.new(token.address);
+
+    let makeCallData = proxy.contract.makeCall.getData(message.address, messageData);
+    let makeCallSig = makeCallData.substring(0, 10);
+
+    assert.equal(true,
+      await token.isCallbackAllowed(accounts[0], proxy.address, makeCallSig, 1)
+    );
+    assert.equal(true,
+      await token.isCallbackAllowed(accounts[0], proxy.address, makeCallSig, 2)
+    );
+    assert.equal(true,
+      await token.isCallbackAllowed(accounts[0], proxy.address, makeCallSig, 3)
+    );
+
+    await token.transferAndCall(
+      proxy.address, 100, makeCallData
+    );
+
+    assert.equal(100, await token.balanceOf(message.address));
+    assert.equal(0, await token.balanceOf(proxy.address));
+    assert.equal(0, await token.balanceOf(accounts[0]));
+  });
+
+});


### PR DESCRIPTION
This is a proposal of changes to ERC827 standard to change the way callbacks works. This fix the issue of undesired callbacks being use in certain contracts.

### Summary
The receiver contract where the callback function will be executed now needs to allow the execution of that callback itself, if the sender attempt to execute a callback that is not allowed on a receiver contract it will fail. 
The callbacks can be allowed to certain address or they can be public, which means that anyone can execute it. There is also the option for a receiver contract to allow the execution of any function from any address.

**The allowedCallbacks mapping works like this:**

Receiver => Sender => Function Signature => FunctionType => Allowed

The `receiver` is the contract where the callbak function will be executed.

The `sender` can be an specific address or it can be 0x0, if it is 0x0 means that is a public callback.

The `function signature` can be an specific signature or it can be 0x0, if it is 0x0 means that any function can be executed.

The `function type` can be 1(approval), 2(transfer) or 3(transferFrom).

The `allowed` variable is a boolean that is true or false depending if the callback is allowed by the sender or not.

**To manage the allowance of the callback the proposal adds two new functions:**

`function allowCallback(address from, bytes4 functionSignature, uint8 fType) public`
`function removeCallback(address from, bytes4 functionSignature, uint8 fType) public`

See the [ERC827TokenAllowedCallbacks](https://github.com/AugustoL/erc827/blob/allowed-callbacks-proposal/contracts/ERC827/proposals/ERC827TokenMockAllowedCallbacks.sol)

**Backwards compatibility**

To work with smart contracts that didnt had werent able to allow specific callbacks to be executed I added a `ERC827Proxy` contract that forwards any arbitrary call with token balance or allowance. This contract only needs to be deployed specifying the token address and it will automatically allow the `makeCall` function to be executed from the token contract.

The PR also add tests for the proposed changes.