### PR TITLE
Add test attacks for ERC827 with proxy proposal

### DIFF
--- a/contracts/ERC827/ERC827.sol
+++ b/contracts/ERC827/ERC827.sol
@@ -28,14 +28,8 @@ contract ERC827 is IERC827, ERC20 {
    * @param _data ABI-encoded contract call to call `_spender` address.
    * @return true if the call function was executed successfully
    */
-  function approveAndCall(
-    address _spender,
-    uint256 _value,
-    bytes _data
-  )
-    public
-    payable
-    returns (bool)
+  function approveAndCall(address _spender, uint256 _value, bytes _data)
+    public payable returns (bool)
   {
     require(_spender != address(this));
 
@@ -55,14 +49,8 @@ contract ERC827 is IERC827, ERC20 {
    * @param _data ABI-encoded contract call to call `_to` address.
    * @return true if the call function was executed successfully
    */
-  function transferAndCall(
-    address _to,
-    uint256 _value,
-    bytes _data
-  )
-    public
-    payable
-    returns (bool)
+  function transferAndCall(address _to, uint256 _value, bytes _data)
+    public payable returns (bool)
   {
     require(_to != address(this));
 
@@ -82,12 +70,7 @@ contract ERC827 is IERC827, ERC20 {
    * @param _data ABI-encoded contract call to call `_to` address.
    * @return true if the call function was executed successfully
    */
-  function transferFromAndCall(
-    address _from,
-    address _to,
-    uint256 _value,
-    bytes _data
-  )
+  function transferFromAndCall(address _from, address _to, uint256 _value, bytes _data)
     public payable returns (bool)
   {
     require(_to != address(this));
@@ -110,11 +93,7 @@ contract ERC827 is IERC827, ERC20 {
    * @param _addedValue The amount of tokens to increase the allowance by.
    * @param _data ABI-encoded contract call to call `_spender` address.
    */
-  function increaseAllowanceAndCall(
-    address _spender,
-    uint _addedValue,
-    bytes _data
-  )
+  function increaseAllowanceAndCall(address _spender, uint _addedValue, bytes _data)
     public
     payable
     returns (bool)
@@ -140,14 +119,8 @@ contract ERC827 is IERC827, ERC20 {
    * @param _subtractedValue The amount of tokens to decrease the allowance by.
    * @param _data ABI-encoded contract call to call `_spender` address.
    */
-  function decreaseAllowanceAndCall(
-    address _spender,
-    uint _subtractedValue,
-    bytes _data
-  )
-    public
-    payable
-    returns (bool)
+  function decreaseAllowanceAndCall(address _spender, uint _subtractedValue, bytes _data)
+    public payable returns (bool)
   {
     require(_spender != address(this));
 

--- a/contracts/ERC827/IERC827.sol
+++ b/contracts/ERC827/IERC827.sol
@@ -15,7 +15,7 @@ contract IERC827 is IERC20 {
   function approveAndCall(address _spender, uint256 _value, bytes _data)
     public payable returns (bool);
 
-  function transferAndCall( address _to, uint256 _value, bytes _data )
+  function transferAndCall(address _to, uint256 _value, bytes _data)
     public payable returns (bool);
 
   function transferFromAndCall(address _from, address _to, uint256 _value, bytes _data)

--- a/contracts/ERC827/proposals/ERC827WithProxy.sol
+++ b/contracts/ERC827/proposals/ERC827WithProxy.sol
@@ -37,14 +37,8 @@ contract ERC827WithProxy is ERC827 {
    * @param _data ABI-encoded contract call to call `_spender` address.
    * @return true if the call function was executed successfully
    */
-  function approveAndCall(
-    address _spender,
-    uint256 _value,
-    bytes _data
-  )
-    public
-    payable
-    returns (bool)
+  function approveAndCall(address _spender, uint256 _value, bytes _data)
+    public payable returns (bool)
   {
     require(_spender != address(this));
 
@@ -65,14 +59,8 @@ contract ERC827WithProxy is ERC827 {
    * @param _data ABI-encoded contract call to call `_to` address.
    * @return true if the call function was executed successfully
    */
-  function transferAndCall(
-    address _to,
-    uint256 _value,
-    bytes _data
-  )
-    public
-    payable
-    returns (bool)
+  function transferAndCall(address _to, uint256 _value, bytes _data)
+    public payable returns (bool)
   {
     require(_to != address(this));
 
@@ -94,12 +82,7 @@ contract ERC827WithProxy is ERC827 {
    * @param _data ABI-encoded contract call to call `_to` address.
    * @return true if the call function was executed successfully
    */
-  function transferFromAndCall(
-    address _from,
-    address _to,
-    uint256 _value,
-    bytes _data
-  )
+  function transferFromAndCall(address _from, address _to, uint256 _value, bytes _data)
     public payable returns (bool)
   {
     require(_to != address(this));
@@ -124,14 +107,8 @@ contract ERC827WithProxy is ERC827 {
    * @param _addedValue The amount of tokens to increase the allowance by.
    * @param _data ABI-encoded contract call to call `_spender` address.
    */
-  function increaseAllowanceAndCall(
-    address _spender,
-    uint _addedValue,
-    bytes _data
-  )
-    public
-    payable
-    returns (bool)
+  function increaseAllowanceAndCall(address _spender, uint _addedValue, bytes _data)
+    public payable returns (bool)
   {
     require(_spender != address(this));
 
@@ -155,14 +132,8 @@ contract ERC827WithProxy is ERC827 {
    * @param _subtractedValue The amount of tokens to decrease the allowance by.
    * @param _data ABI-encoded contract call to call `_spender` address.
    */
-  function decreaseAllowanceAndCall(
-    address _spender,
-    uint _subtractedValue,
-    bytes _data
-  )
-    public
-    payable
-    returns (bool)
+  function decreaseAllowanceAndCall(address _spender, uint _subtractedValue, bytes _data)
+    public payable returns (bool)
   {
     require(_spender != address(this));
 

--- a/test/examples/VaultAttack.js
+++ b/test/examples/VaultAttack.js
@@ -1,6 +1,4 @@
 
-import EVMRevert from '../helpers/EVMRevert';
-var Message = artifacts.require('MessageHelper');
 var ERC827TokenMock = artifacts.require('ERC827TokenMock');
 var VaultAttack = artifacts.require('VaultAttack');
 


### PR DESCRIPTION
Add missing tests to prove existent attacks on erc827 implementation cant be executed on erc827 with proxy implementation.