### PR TITLE
Add ERC827Migratable

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@
 
 `npm test`
 
+# ERC20 Migration
+
+The contract [ERC827Migratable](contracts/ERC827/ERC827Migratable.sol) can be used to migrate balances from a ERC20 token.
+The migration can be opt-in or forced, enabling the use of the opt-in method will allow users to migrate their balances from the ERC20 token themselves and the forced migration will allow the owner of the ERC827 token to issue the same balance from the ERC20 token to any address.
+
+*Important notes*
+- If the contract doesn't support the `_mint` function you have to change it to add the right balance to the `balances` and `totalSupply` variables.
+- Allow the owner of the ERC827 contract to use the forced migration only when the ERC20 token is paused or cant execute any more tranfers, if not you will end up with two tokens active and duplicated balances.
+
 ## Developer Resources
 
 - ERC827 EIP: https://github.com/ethereum/EIPs/issues/827

--- a/contracts/ERC827/ERC827Migratable.sol
+++ b/contracts/ERC827/ERC827Migratable.sol
@@ -1,0 +1,54 @@
+/* solium-disable security/no-low-level-calls */
+
+pragma solidity ^0.5.0;
+
+import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
+import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+import "./ERC827.sol";
+
+/**
+ * @title ERC827Migratable
+ *
+ * @dev An extension for an ERC827 token that allows the balance migration from
+ * an ERC20 token, once the balance is moved to the ERC827 it cant be moved
+ * back to the ERC20 contract.
+ */
+contract ERC827Migratable is ERC827, Ownable {
+
+  IERC20 public erc20Token;
+
+
+  /**
+   * @dev Constructor
+   * @param _erc20Token The address of the erc20 token where the balances will
+   * be migrated.
+   */
+  constructor(address _erc20Token) public {
+    require(_erc20Token != address(0), "Incorrect ERC20 token address");
+    erc20Token = IERC20(_erc20Token);
+  }
+
+  /**
+   * @dev Migrates the approved balance from the ERC20 token to this contract
+   * and adds the new balance to the msg.sender
+   */
+  function migrate() public {
+    uint256 balanceToMigrate = erc20Token.allowance(msg.sender, address(this));
+    erc20Token.transferFrom(msg.sender, address(this), balanceToMigrate);
+    _mint(msg.sender, balanceToMigrate);
+  }
+
+  /**
+   * @dev Migrates the approved balance from the ERC20 token * to this contract
+   * and adds the new balance to the _from address
+   */
+  function migrateFrom(address _from) public onlyOwner {
+    require(_from != address(0), "Cant migrate burned tokens");
+    require(
+      _from != address(this),
+      "Cant migrate tokens that already have been migrated"
+    );
+    _mint(_from, erc20Token.balanceOf(_from));
+  }
+
+}

--- a/test/ERC827/ERC20Migration.js
+++ b/test/ERC827/ERC20Migration.js
@@ -1,0 +1,73 @@
+
+import EVMRevert from '../helpers/EVMRevert';
+var ERC20TokenMock = artifacts.require('ERC20TokenMock');
+var ERC827Migratable = artifacts.require('ERC827Migratable');
+
+require('chai').use(require('chai-as-promised')).should();
+const assert = require('chai').assert;
+
+contract('ERC827Migratable', function (accounts) {
+  let erc20Token, erc827Token;
+
+  beforeEach(async function () {
+    erc20Token = await ERC20TokenMock.new(accounts[1], 100);
+    erc827Token = await ERC827Migratable.new(erc20Token.address);
+    await erc20Token.transfer(accounts[2], 10, { from: accounts[1] });
+    await erc20Token.transfer(accounts[3], 20, { from: accounts[1] });
+    await erc20Token.transfer(accounts[4], 30, { from: accounts[1] });
+  });
+
+  it.only('should change erc20 balance after opt-in migration', async function () {
+    await erc20Token.approve(erc827Token.address, 10, { from: accounts[2] });
+    await erc827Token.migrate({ from: accounts[2] });
+    await erc20Token.approve(erc827Token.address, 15, { from: accounts[3] });
+    await erc827Token.migrate({ from: accounts[3] });
+
+    // Check balances
+    assert.equal(await erc20Token.balanceOf(accounts[2]), 0);
+    assert.equal(await erc20Token.balanceOf(accounts[3]), 5);
+    assert.equal(await erc827Token.balanceOf(accounts[2]), 10);
+    assert.equal(await erc827Token.balanceOf(accounts[3]), 15);
+
+    // Check ERC827 total supply
+    assert.equal(await erc827Token.totalSupply(), 25);
+  });
+
+  it.only('should change erc20 balance after forced migration', async function () {
+    await erc827Token.migrateFrom(accounts[3], { from: accounts[0] });
+
+    // Check balances
+    assert.equal(await erc20Token.balanceOf(accounts[3]), 20);
+    assert.equal(await erc827Token.balanceOf(accounts[3]), 20);
+
+    // Check ERC827 total supply
+    assert.equal(await erc827Token.totalSupply(), 20);
+  });
+
+  it.only('should change erc20 balance after opt-in and forced migration', async function () {
+    await erc20Token.approve(erc827Token.address, 10, { from: accounts[2] });
+    await erc827Token.migrate({ from: accounts[2] });
+    await erc20Token.approve(erc827Token.address, 20, { from: accounts[3] });
+    await erc827Token.migrate({ from: accounts[3] });
+
+    await erc827Token.migrateFrom(accounts[1], { from: accounts[0] });
+    await erc827Token.migrateFrom(accounts[4], { from: accounts[0] });
+
+    // Should revert the migration of already migrated tokens
+    await erc827Token.migrateFrom(erc827Token.address, { from: accounts[0] })
+      .should.be.rejectedWith(EVMRevert);
+
+    // Check balances
+    assert.equal(await erc20Token.balanceOf(accounts[1]), 40);
+    assert.equal(await erc20Token.balanceOf(accounts[2]), 0);
+    assert.equal(await erc20Token.balanceOf(accounts[3]), 0);
+    assert.equal(await erc20Token.balanceOf(accounts[4]), 30);
+    assert.equal(await erc827Token.balanceOf(accounts[1]), 40);
+    assert.equal(await erc827Token.balanceOf(accounts[2]), 10);
+    assert.equal(await erc827Token.balanceOf(accounts[3]), 20);
+    assert.equal(await erc827Token.balanceOf(accounts[4]), 30);
+
+    // Check ERC827 total supply
+    assert.equal(await erc827Token.totalSupply(), 100);
+  });
+});


### PR DESCRIPTION
Adds the ERC827Migratable contract, an ERC827 token that takes the balances from an ERC20 token by executing migration functions from the token holders or ERC827 token owner.